### PR TITLE
Allow tags to be passed to all resources in the module, add ignore to IAM Policies, adds Encryption to S3, and Blocks Public Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ No modules.
 | <a name="input_rad-security_assumed_role_arn"></a> [rad-security\_assumed\_role\_arn](#input\_rad-security\_assumed\_role\_arn) | Rad Security Role that will assume the rad-security-connect IAM role you create to interact with resources in your account | `string` | `"arn:aws:iam::955322216602:role/rad-security-connector"` | no |
 | <a name="input_rad-security_deprecated_assumed_role_arn"></a> [rad-security\_deprecated\_assumed\_role\_arn](#input\_rad-security\_deprecated\_assumed\_role\_arn) | Deprecated Rad Security Role that will assume the rad-security-connect IAM role you create to interact with resources in your account. This role will be removed in the future. | `string` | `"arn:aws:iam::955322216602:role/ksoc-connector"` | no |
 | <a name="input_rad-security_eks_audit_logs_assumed_role_arn"></a> [rad-security\_eks\_audit\_logs\_assumed\_role\_arn](#input\_rad-security\_eks\_audit\_logs\_assumed\_role\_arn) | Rad Security Role dedicated for EKS audit logs that will be allowed to assume | `string` | `"arn:aws:iam::955322216602:role/ksoc-data-pipeline"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A set of tags to associate with the resources in this module. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ No modules.
 | [aws_iam_role_policy_attachment.rad-security_connect_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kinesis_firehose_delivery_stream.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_s3_bucket.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_public_access_block.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [rad-security_aws_register.this](https://registry.terraform.io/providers/rad-security/rad-security/latest/docs/resources/aws_register) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |

--- a/actions.tf
+++ b/actions.tf
@@ -267,7 +267,7 @@ locals {
   slice(local.aws_iam_actions, i, min(i + local.policy_action_size, length(local.aws_iam_actions)))]
 }
 
-
+# trivy:ignore:AVD-AWS-0057
 resource "aws_iam_policy" "connect_policy" {
   for_each = { for idx, sa in local.policy_actions : idx => sa }
 

--- a/eks_audit_logs.tf
+++ b/eks_audit_logs.tf
@@ -36,6 +36,24 @@ resource "aws_s3_bucket" "audit_logs" {
   })
 }
 
+resource "aws_s3_bucket_public_access_block" "audit_logs" {
+  bucket = aws_s3_bucket.audit_logs[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "audit_logs" {
+  bucket = aws_s3_bucket.audit_logs[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket_versioning" "audit_logs" {
   count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
   bucket = aws_s3_bucket.audit_logs[0].id
@@ -70,6 +88,7 @@ data "aws_iam_policy_document" "firehose_to_s3" {
   }
 }
 
+# trivy:ignore:AVD-AWS-0057
 resource "aws_iam_role" "firehose" {
   count              = var.enable_eks_audit_logs_pipeline ? 1 : 0
   name               = "ksoc-firehose"

--- a/eks_audit_logs.tf
+++ b/eks_audit_logs.tf
@@ -16,6 +16,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose" {
   count       = var.enable_eks_audit_logs_pipeline ? 1 : 0
   name        = "ksoc-audit-logs"
   destination = "extended_s3"
+  tags        = var.tags
 
   extended_s3_configuration {
     role_arn   = aws_iam_role.firehose[0].arn
@@ -30,9 +31,9 @@ resource "aws_s3_bucket" "audit_logs" {
   count         = var.enable_eks_audit_logs_pipeline ? 1 : 0
   bucket        = local.bucket_name
   force_destroy = true
-  tags = {
+  tags = merge(var.tags, {
     ksoc-data-type = "eks-audit-logs"
-  }
+  })
 }
 
 resource "aws_s3_bucket_versioning" "audit_logs" {
@@ -77,6 +78,7 @@ resource "aws_iam_role" "firehose" {
     name   = "ksoc-firehose-to-s3-policy"
     policy = data.aws_iam_policy_document.firehose_to_s3[0].json
   }
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "cloudwatch_assume" {
@@ -110,6 +112,7 @@ resource "aws_iam_role" "cloudwatch" {
     name   = "ksoc-cloudwatch-logs-to-firehose-policy"
     policy = data.aws_iam_policy_document.logs_to_firehose[0].json
   }
+  tags = var.tags
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "subscription_filter" {
@@ -140,6 +143,7 @@ data "aws_iam_policy_document" "ksoc_s3_access" {
 resource "aws_iam_policy" "ksoc_s3_access" {
   count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
   policy = data.aws_iam_policy_document.ksoc_s3_access[0].json
+  tags   = var.tags
 }
 
 data "aws_iam_policy_document" "ksoc_assume" {
@@ -160,6 +164,7 @@ resource "aws_iam_role" "ksoc_s3_access" {
   name                 = "ksoc-audit-logs"
   path                 = "/"
   max_session_duration = 3600
+  tags                 = var.tags
 
   assume_role_policy = data.aws_iam_policy_document.ksoc_assume[0].json
 }

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "aws_iam_role" "this" {
 resource "aws_iam_instance_profile" "this" {
   name = aws_iam_role.this.name
   role = aws_iam_role.this.name
+  tags = var.tags
 }
 
 resource "rad-security_aws_register" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,9 @@ variable "eks_audit_logs_multi_region" {
   default     = false
   description = "Enable multi-region support for the EKS audit logs. This requires creating subscription filters in each region outside of this module. See documentation for more information."
 }
+
+variable "tags" {
+  description = "A set of tags to associate with the resources in this module."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
We did not have a way to propagate tags to all resources within this module. This PR fixes that by adding a tags input variable. 

The IAM Policy was triggering security issues, so I added an ignore comment above them. The S3 bucket did not have encryption enabled and was not blocking public access so that was added as well.  