### PR TITLE
Fix invalid index error when eks_audit_logs_pipeline is disabled

### DIFF
--- a/eks_audit_logs.tf
+++ b/eks_audit_logs.tf
@@ -37,6 +37,7 @@ resource "aws_s3_bucket" "audit_logs" {
 }
 
 resource "aws_s3_bucket_public_access_block" "audit_logs" {
+  count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
   bucket = aws_s3_bucket.audit_logs[0].id
 
   block_public_acls       = true
@@ -46,6 +47,7 @@ resource "aws_s3_bucket_public_access_block" "audit_logs" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "audit_logs" {
+  count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
   bucket = aws_s3_bucket.audit_logs[0].id
   rule {
     apply_server_side_encryption_by_default {


### PR DESCRIPTION
Disables the creation of the `aws_s3_bucket_public_access_block` and `aws_s3_bucket_server_side_encryption_configuration` when `enable_eks_audit_logs_pipeline` is set to false.

This fixes this error
```
╷
│ Error: Invalid index
│
│   on .rad-security-connect/eks_audit_logs.tf line 40, in resource "aws_s3_bucket_public_access_block" "audit_logs":
│   40:   bucket = aws_s3_bucket.audit_logs[0].id
│     ├────────────────
│     │ aws_s3_bucket.audit_logs is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
╵
╷
│ Error: Invalid index
│
│   on .rad-security-connect/eks_audit_logs.tf line 49, in resource "aws_s3_bucket_server_side_encryption_configuration" "audit_logs":
│   49:   bucket = aws_s3_bucket.audit_logs[0].id
│     ├────────────────
│     │ aws_s3_bucket.audit_logs is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
╵
```
