### PR TITLE
Add External ID conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_external_id"></a> [aws\_external\_id](#input\_aws\_external\_id) | External ID to use when connecting an AWS account with Rad | `string` | `""` | no |
 | <a name="input_eks_audit_logs_bucket_versioning_enabled"></a> [eks\_audit\_logs\_bucket\_versioning\_enabled](#input\_eks\_audit\_logs\_bucket\_versioning\_enabled) | Enable versioning for the S3 bucket that will store EKS audit logs | `bool` | `true` | no |
 | <a name="input_eks_audit_logs_filter_pattern"></a> [eks\_audit\_logs\_filter\_pattern](#input\_eks\_audit\_logs\_filter\_pattern) | The Cloudwatch Log Subscription Filter pattern | `string` | `"{ $.stage = \"ResponseComplete\" && $.requestURI != \"/version\" && $.requestURI != \"/version?*\" && $.requestURI != \"/metrics\" && $.requestURI != \"/metrics?*\" && $.requestURI != \"/logs\" && $.requestURI != \"/logs?*\" && $.requestURI != \"/swagger*\" && $.requestURI != \"/livez*\" && $.requestURI != \"/readyz*\" && $.requestURI != \"/healthz*\" }"` | no |
 | <a name="input_eks_audit_logs_multi_region"></a> [eks\_audit\_logs\_multi\_region](#input\_eks\_audit\_logs\_multi\_region) | Enable multi-region support for the EKS audit logs. This requires creating subscription filters in each region outside of this module. See documentation for more information. | `bool` | `false` | no |

--- a/actions.tf
+++ b/actions.tf
@@ -275,9 +275,7 @@ resource "aws_iam_policy" "connect_policy" {
   path        = "/"
   description = "Part ${each.key} of the policy required for rad-security-connect"
 
-  tags = {
-    app = "rad-security"
-  }
+  tags = var.tags
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -287,6 +285,7 @@ resource "aws_iam_policy" "connect_policy" {
       Resource = "*"
     }]
   })
+
 }
 
 resource "aws_iam_role_policy_attachment" "rad-security_connect_policy_attachment" {

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,15 @@ data "aws_iam_policy_document" "assume_role" {
       type        = "AWS"
       identifiers = [var.rad-security_assumed_role_arn, var.rad-security_deprecated_assumed_role_arn]
     }
+
+    dynamic "condition" {
+      for_each = var.aws_external_id != "" ? [var.aws_external_id] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [condition.value]
+      }
+    }
   }
 }
 
@@ -20,6 +29,7 @@ resource "aws_iam_role" "this" {
   path                 = "/"
   max_session_duration = 3600
   description          = "IAM role for rad-security-connect"
+  tags                 = var.tags
 
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "aws_external_id" {
+  description = "External ID to use when connecting an AWS account with Rad"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Adds Support for External IDs within our AWS Connect Module.

The Role and policies were using old tags, so they were changed to use the variable that is provided in the module.  