### PR TITLE
Add lambda:ListTag action

### DIFF
--- a/actions.tf
+++ b/actions.tf
@@ -172,6 +172,7 @@ locals {
     "lambda:ListFunctionUrlConfigs",
     "lambda:ListFunctions",
     "lambda:ListProvisionedConcurrencyConfigs",
+    "lambda:ListTags",
     "lambda:ListVersionsByFunction",
     "lightsail:GetContainerServiceDeployments",
     "lightsail:GetContainerServices",


### PR DESCRIPTION
We were syncing Lambdas in AWS, but we did not grant the ListTags permission. This PR adds it. 