### PR TITLE
Add sts:TagSession action to ksoc-audit-logs role

### DIFF
--- a/eks_audit_logs.tf
+++ b/eks_audit_logs.tf
@@ -170,8 +170,10 @@ resource "aws_iam_policy" "ksoc_s3_access" {
 data "aws_iam_policy_document" "ksoc_assume" {
   count = var.enable_eks_audit_logs_pipeline ? 1 : 0
   statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole", "sts:TagSession"
+    ]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
After moving to EKS Pod Identity we need to add extra permission to ksoc-audit-logs to be able to assumeRole and download audit logs from our customer's S3

Towards: https://linear.app/rad-security/issue/ENG-2186/fix-rad-connect-terraform-to-allow-to-read-audit-logs