### PR TITLE
Use aws_iam_role_policy resources instead of inline_policy within aws_iam_role resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ No modules.
 | [aws_iam_role.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.cloudwatch_to_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.firehose_to_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.rad-security_connect_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kinesis_firehose_delivery_stream.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |


### PR DESCRIPTION
We are getting the deprecation warnings like the following. 
```
with module.rad_security_connect_primary.aws_iam_role.cloudwatch[0],
on .terraform/modules/rad_security_connect_primary/eks_audit_logs.tf line 127, in resource "aws_iam_role" "cloudwatch":
127: resource "aws_iam_role" "cloudwatch" {

inline_policy is deprecated. Use the aws_iam_role_policy resource instead.
If Terraform should exclusively manage all inline policy associations (the
current behavior of this argument), use the aws_iam_role_policies_exclusive
resource as well.
```

This PR moves the Role Policy creation to use aws_iam_role_policy resources instead of configuring it within inline_policy in aws_iam_role resources. 