### PR TITLE
Adds 7 day lifecycle policy to the eks audit logs bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ No modules.
 | [aws_iam_role_policy_attachment.rad-security_connect_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kinesis_firehose_delivery_stream.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_s3_bucket.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_public_access_block.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |

--- a/s3_lifecycle.tf
+++ b/s3_lifecycle.tf
@@ -1,0 +1,23 @@
+resource "aws_s3_bucket_lifecycle_configuration" "audit_logs" {
+  count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  bucket = aws_s3_bucket.audit_logs[0].bucket
+
+  rule {
+    id     = "delete-old-objects"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}


### PR DESCRIPTION
Sets the lifecycle of objects in the eks audit logs bucket to 7 days to reduce the number of objects stored in the bucket. 