### PR TITLE
Separate TagSession from AssumeRole permission

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,12 +5,11 @@ data "aws_iam_policy_document" "assume_role" {
     effect = "Allow"
     actions = [
       "sts:AssumeRole",
-      "sts:TagSession"
     ]
 
     principals {
       type        = "AWS"
-      identifiers = [var.rad-security_assumed_role_arn, var.rad-security_deprecated_assumed_role_arn]
+      identifiers = [var.rad-security_assumed_role_arn]
     }
 
     dynamic "condition" {
@@ -20,6 +19,18 @@ data "aws_iam_policy_document" "assume_role" {
         variable = "sts:ExternalId"
         values   = [condition.value]
       }
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:TagSession"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.rad-security_assumed_role_arn]
     }
   }
 }


### PR DESCRIPTION
`TagSession` cannot be used together with `ExternalId` condition, therefore we separate the statements.

We also drop support for the depracated roles.