### PR TITLE
Add inspector2:ListFindings permission

### DIFF
--- a/actions.tf
+++ b/actions.tf
@@ -260,6 +260,7 @@ locals {
     "iam:ListVirtualMFADevices",
     "inspector2:DescribeOrganizationConfiguration",
     "inspector2:ListCoverage",
+    "inspector2:ListFindings",
     "inspector:ListFindings",
     "kafka:DescribeConfiguration",
     "kafka:GetBootstrapBrokers",


### PR DESCRIPTION
## Summary
- Add `inspector2:ListFindings` IAM action so RAD Security can read AWS Inspector v2 findings